### PR TITLE
Enable RTMP Client to Look for a Live Stream

### DIFF
--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -2223,7 +2223,7 @@ SendPlay(RTMP *r)
       if (r->Link.seekTime > 0.0)
 	enc = AMF_EncodeNumber(enc, pend, r->Link.seekTime);	/* resume from here */
       else
-	enc = AMF_EncodeNumber(enc, pend, 0.0);	/*-2000.0);*/ /* recorded as default, -2000.0 is not reliable since that freezes the player if the stream is not found */
+	enc = AMF_EncodeNumber(enc, pend, -2000.0); /* corresponds to -2 in the comment above */
     }
   if (!enc)
     return FALSE;


### PR DESCRIPTION
The client now looks for a live stream and falls back to a recorded
stream if no live stream is found. Proposed fix for #65 