### PR TITLE
Add a connection timeout to the socket

### DIFF
--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -31,7 +31,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeAlloc(JNIEnv* env, jobject th
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz, jstring url_,
                                                         jboolean isPublishMode, jlong rtmpPointer,
-                                                        jint timeout) {
+                                                        jint sendTimeoutInMs, jint receiveTimeoutInS) {
 
     const char *url = (*env)->GetStringUTFChars(env, url_, NULL);
     RTMP *rtmp = (RTMP *) rtmpPointer;
@@ -41,7 +41,8 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thi
     }
 
     RTMP_Init(rtmp);
-    rtmp->Link.timeout = timeout;
+    rtmp->Link.timeout = receiveTimeoutInS;
+    rtmp->Link.sendTimeoutInMs = sendTimeoutInMs;
     int ret = RTMP_SetupURL(rtmp, url);
 
     if (!ret) {

--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -41,7 +41,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thi
     }
 
     RTMP_Init(rtmp);
-    rtmp->Link.timeout = receiveTimeoutInMs;
+    rtmp->Link.receiveTimeoutInMs = receiveTimeoutInMs;
     rtmp->Link.sendTimeoutInMs = sendTimeoutInMs;
     int ret = RTMP_SetupURL(rtmp, url);
 

--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -31,7 +31,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeAlloc(JNIEnv* env, jobject th
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz, jstring url_,
                                                         jboolean isPublishMode, jlong rtmpPointer,
-                                                        jint sendTimeoutInMs, jint receiveTimeoutInS) {
+                                                        jint sendTimeoutInMs, jint receiveTimeoutInMs) {
 
     const char *url = (*env)->GetStringUTFChars(env, url_, NULL);
     RTMP *rtmp = (RTMP *) rtmpPointer;
@@ -41,7 +41,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thi
     }
 
     RTMP_Init(rtmp);
-    rtmp->Link.timeout = receiveTimeoutInS;
+    rtmp->Link.timeout = receiveTimeoutInMs;
     rtmp->Link.sendTimeoutInMs = sendTimeoutInMs;
     int ret = RTMP_SetupURL(rtmp, url);
 

--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -30,7 +30,8 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeAlloc(JNIEnv* env, jobject th
  */
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz, jstring url_,
-                                                        jboolean isPublishMode, jlong rtmpPointer) {
+                                                        jboolean isPublishMode, jlong rtmpPointer,
+                                                        jint timeout) {
 
     const char *url = (*env)->GetStringUTFChars(env, url_, NULL);
     RTMP *rtmp = (RTMP *) rtmpPointer;
@@ -40,6 +41,7 @@ Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thi
     }
 
     RTMP_Init(rtmp);
+    rtmp->Link.timeout = timeout;
     int ret = RTMP_SetupURL(rtmp, url);
 
     if (!ret) {

--- a/rtmp-client/src/main/cpp/librtmp-jni.h
+++ b/rtmp-client/src/main/cpp/librtmp-jni.h
@@ -18,7 +18,8 @@ extern "C" {
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz,
                                                         jstring url, jboolean isPublishMode,
-                                                        jlong rtmpPointer, jint timeout);
+                                                        jlong rtmpPointer, jint sendTimeoutInMs,
+                                                        jint receiveTimeoutInS);
 
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient

--- a/rtmp-client/src/main/cpp/librtmp-jni.h
+++ b/rtmp-client/src/main/cpp/librtmp-jni.h
@@ -18,7 +18,7 @@ extern "C" {
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz,
                                                         jstring url, jboolean isPublishMode,
-                                                        jlong rtmpPointer);
+                                                        jlong rtmpPointer, jint timeout);
 
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient

--- a/rtmp-client/src/main/cpp/librtmp-jni.h
+++ b/rtmp-client/src/main/cpp/librtmp-jni.h
@@ -19,7 +19,7 @@ JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RtmpClient_nativeOpen(JNIEnv* env, jobject thiz,
                                                         jstring url, jboolean isPublishMode,
                                                         jlong rtmpPointer, jint sendTimeoutInMs,
-                                                        jint receiveTimeoutInS);
+                                                        jint receiveTimeoutInMs);
 
 /*
  * Class:     net_butterflytv_rtmp_client_RtmpClient

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -338,8 +338,7 @@ RTMP_Init(RTMP *r)
   r->m_nServerBW = 2500000;
   r->m_fAudioCodecs = 3191.0;
   r->m_fVideoCodecs = 252.0;
-  //Changing units to milliseconds. Changing from 10 to 10000.
-  r->Link.timeout = 10000;
+  r->Link.receiveTimeoutInMs = 10000;
   r->Link.swfAge = 30;
 }
 
@@ -518,7 +517,7 @@ RTMP_SetupStream(RTMP *r,
   r->Link.stopTime = dStop;
   if (bLiveStream)
     r->Link.lFlags |= RTMP_LF_LIVE;
-  r->Link.timeout = timeoutInMs;
+  r->Link.receiveTimeoutInMs = timeoutInMs;
 
   r->Link.protocol = protocol;
   r->Link.hostname = *host;
@@ -585,7 +584,7 @@ static struct urlopt {
   	"Stream stop position in milliseconds" },
   { AVC("buffer"),    OFF(m_nBufferMS),        OPT_INT, 0,
   	"Buffer time in milliseconds" },
-  { AVC("timeout"),   OFF(Link.timeout),       OPT_INT, 0,
+  { AVC("timeout"),   OFF(Link.receiveTimeoutInMs),       OPT_INT, 0,
   	"Session timeout in seconds" },
   { AVC("pubUser"),   OFF(Link.pubUser),       OPT_STR, 0,
         "Publisher username" },
@@ -951,13 +950,13 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service)
   {
     struct timeval tv;
 
-    tv.tv_sec = r->Link.timeout / 1000;
-    tv.tv_usec = (r->Link.timeout % 1000) * 1000;
+    tv.tv_sec = r->Link.receiveTimeoutInMs / 1000;
+    tv.tv_usec = (r->Link.receiveTimeoutInMs % 1000) * 1000;
     if (setsockopt
         (r->m_sb.sb_socket, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv)))
       {
-        RTMP_Log(RTMP_LOGERROR, "%s, Setting socket timeout to %ds failed!",
-	    __FUNCTION__, r->Link.timeout);
+        RTMP_Log(RTMP_LOGERROR, "%s, Setting socket timeout to %dms failed!",
+	    __FUNCTION__, r->Link.receiveTimeoutInMs);
       }
   }
 

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -910,9 +910,11 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service)
   if (r->m_sb.sb_socket != -1)
     {
       int err;
-      SET_RCVTIMEO(tv, r->Link.timeout);
+      struct timeval send_timeout;
 
-      err = setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+      send_timeout.tv_sec = r->Link.sendTimeoutInMs / 1000;
+      send_timeout.tv_usec = (r->Link.sendTimeoutInMs % 1000) * 1000;
+      err = setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
       if (err)
         {
           RTMP_Log(RTMP_LOGERROR, "Error %d setting SO_SNDTIMEO", errno);

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -909,6 +909,15 @@ RTMP_Connect0(RTMP *r, struct sockaddr * service)
   r->m_sb.sb_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (r->m_sb.sb_socket != -1)
     {
+      int err;
+      SET_RCVTIMEO(tv, r->Link.timeout);
+
+      err = setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+      if (err)
+        {
+          RTMP_Log(RTMP_LOGERROR, "Error %d setting SO_SNDTIMEO", errno);
+        }
+
       if (connect(r->m_sb.sb_socket, service, sizeof(struct sockaddr)) < 0)
 	{
 	  int err = GetSockError();

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.h
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.h
@@ -176,8 +176,8 @@ extern "C"
     int swfAge;
 
     int protocol;
-    int timeout;                /* connection timeout in milliseconds */
-    int sendTimeoutInMs;        /* socket send timeout in milliseconds */
+    int receiveTimeoutInMs;
+    int sendTimeoutInMs;
 
 #define RTMP_PUB_NAME   0x0001  /* send login to server */
 #define RTMP_PUB_RESP   0x0002  /* send salted password hash */

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.h
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.h
@@ -176,7 +176,7 @@ extern "C"
     int swfAge;
 
     int protocol;
-    int timeout;                /* connection timeout in seconds */
+    int timeout;                /* connection timeout in milliseconds */
     int sendTimeoutInMs;        /* socket send timeout in milliseconds */
 
 #define RTMP_PUB_NAME   0x0001  /* send login to server */
@@ -312,7 +312,7 @@ extern "C"
 			AVal *subscribepath,
 			AVal *usherToken,
 			int dStart,
-			int dStop, int bLiveStream, long int timeout);
+			int dStop, int bLiveStream, long int timeoutInMs);
 
   int RTMP_Connect(RTMP *r, RTMPPacket *cp);
   struct sockaddr;

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.h
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.h
@@ -176,7 +176,8 @@ extern "C"
     int swfAge;
 
     int protocol;
-    int timeout;		/* connection timeout in seconds */
+    int timeout;                /* connection timeout in seconds */
+    int sendTimeoutInMs;        /* socket send timeout in milliseconds */
 
 #define RTMP_PUB_NAME   0x0001  /* send login to server */
 #define RTMP_PUB_RESP   0x0002  /* send salted password hash */

--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
@@ -13,7 +13,17 @@ public class RtmpClient {
 
 
     private final static int OPEN_SUCCESS = 1;
+    private final static int TIMEOUT = 10;
     private long rtmpPointer = 0;
+
+    /* Timeout value in seconds */
+    private int timeout = TIMEOUT;
+    /* Sets the timeout variable */
+    public void setTimeout(int timeout) {
+        if (timeout > 0) {
+            this.timeout = timeout;
+        }
+    }
 
     public static class RtmpIOException extends IOException {
 
@@ -50,7 +60,7 @@ public class RtmpClient {
 
     public void open(String url, boolean isPublishMode) throws RtmpIOException {
         rtmpPointer = nativeAlloc();
-        int result = nativeOpen(url, isPublishMode, rtmpPointer);
+        int result = nativeOpen(url, isPublishMode, rtmpPointer, timeout);
         if (result != OPEN_SUCCESS) {
             rtmpPointer = 0;
             throw new RtmpIOException(result);
@@ -72,7 +82,7 @@ public class RtmpClient {
      *
      * returns {@link #OPEN_SUCCESS} if it is successful, throws RtmpIOException if it is failed
      */
-    private native int nativeOpen(String url, boolean isPublishMode, long rtmpPointer);
+    private native int nativeOpen(String url, boolean isPublishMode, long rtmpPointer, int timeout);
 
     /**
      * read data from rtmp connection

--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
@@ -61,7 +61,7 @@ public class RtmpClient {
      * Parameter expects a non-zero positive integer and will reset timeout to the default value
      * (10000 ms) if zero or a negative integer is passed.
      *  */
-    public void setSendTimeoutInMs(int sendTimeoutInMs) {
+    public void setSendTimeout(int sendTimeoutInMs) {
         if (sendTimeoutInMs > 0) {
             this.sendTimeoutInMs = sendTimeoutInMs;
         } else {
@@ -76,7 +76,7 @@ public class RtmpClient {
      * Parameter expects a non-zero positive integer and will reset timeout to the default value
      * (10000 ms) if zero or a negative integer is passed.
      *  */
-    public void setReceiveTimeoutInMs(int receiveTimeoutInMs) {
+    public void setReceiveTimeout(int receiveTimeoutInMs) {
         if (receiveTimeoutInMs > 0) {
             this.receiveTimeoutInMs = receiveTimeoutInMs;
         } else {

--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RtmpClient.java
@@ -19,7 +19,7 @@ public class RtmpClient {
     /** Socket send timeout value in milliseconds */
     private int sendTimeoutInMs = TIMEOUT_IN_MS;
     /** Socket receive timeout value in seconds */
-    private int receiveTimeoutInS = (TIMEOUT_IN_MS / 1000);
+    private int receiveTimeoutInMs = TIMEOUT_IN_MS;
 
     public static class RtmpIOException extends IOException {
 
@@ -71,22 +71,23 @@ public class RtmpClient {
 
     /**
      *  Sets the socket's receive timeout value
-     * @param receiveTimeoutInS
-     * The receive timeout value for the rtmp socket in <b>seconds</b>.
+     * @param receiveTimeoutInMs
+     * The receive timeout value for the rtmp socket in milliseconds.
      * Parameter expects a non-zero positive integer and will reset timeout to the default value
-     * (10s) if zero or a negative integer is passed.
+     * (10000 ms) if zero or a negative integer is passed.
      *  */
-    public void setReceiveTimeoutInS(int receiveTimeoutInS) {
-        if (receiveTimeoutInS > 0) {
-            this.receiveTimeoutInS = receiveTimeoutInS;
+    public void setReceiveTimeoutInMs(int receiveTimeoutInMs) {
+        if (receiveTimeoutInMs > 0) {
+            this.receiveTimeoutInMs = receiveTimeoutInMs;
         } else {
-            this.receiveTimeoutInS = (TIMEOUT_IN_MS / 1000);
+            this.receiveTimeoutInMs = TIMEOUT_IN_MS;
         }
     }
 
     public void open(String url, boolean isPublishMode) throws RtmpIOException {
         rtmpPointer = nativeAlloc();
-        int result = nativeOpen(url, isPublishMode, rtmpPointer, sendTimeoutInMs, receiveTimeoutInS);
+        int result = nativeOpen(url, isPublishMode, rtmpPointer, sendTimeoutInMs,
+            receiveTimeoutInMs);
         if (result != OPEN_SUCCESS) {
             rtmpPointer = 0;
             throw new RtmpIOException(result);
@@ -109,7 +110,7 @@ public class RtmpClient {
      * returns {@link #OPEN_SUCCESS} if it is successful, throws RtmpIOException if it is failed
      */
     private native int nativeOpen(String url, boolean isPublishMode, long rtmpPointer,
-        int sendTimeoutInMs, int receiveTimeoutInS);
+        int sendTimeoutInMs, int receiveTimeoutInMs);
 
     /**
      * read data from rtmp connection


### PR DESCRIPTION
When using invalid URL, without an explicit timeout, the connection
would fail only after 60s, which is too long. Let the nativeOpen()
method set a timeout and if it doesn't, use a default timeout of 10s. 

Allows this timeout value to be set from the application.

#67 and https://github.com/google/ExoPlayer/issues/4249 will be solved with this commit.