### PR TITLE
Fix error return values from nativeRead

### DIFF
--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -120,11 +120,13 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_nativeWrite
     RTMP *rtmp = (RTMP *) rtmpPointer;
     if (rtmp == NULL) {
         throwIOException(env, "First call open function");
+        return 0;
     }
 
     int connected = RTMP_IsConnected(rtmp);
     if (!connected) {
         throwIOException(env, "Connection to server is lost");
+        return 0;
     }
 
     return RTMP_Write(rtmp, data, size);
@@ -152,6 +154,7 @@ JNIEXPORT bool JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_nativePause
     RTMP *rtmp = (RTMP *) rtmpPointer;
     if (rtmp == NULL) {
         throwIOException(env, "First call open function");
+        return false;
     }
 
     int DoPause = 0;

--- a/rtmp-client/src/main/cpp/librtmp-jni.c
+++ b/rtmp-client/src/main/cpp/librtmp-jni.c
@@ -76,10 +76,12 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_nativeRead
     RTMP *rtmp = (RTMP *) rtmpPointer;
     if (rtmp == NULL) {
         throwIOException(env, "First call open function");
+        return 0;
     }
     int connected = RTMP_IsConnected(rtmp);
     if (!connected) {
         throwIOException(env, "Connection to server is lost");
+        return 0;
     }
 
     char* data = malloc(size*sizeof(char));
@@ -90,8 +92,19 @@ JNIEXPORT jint JNICALL Java_net_butterflytv_rtmp_1client_RtmpClient_nativeRead
         (*env)->SetByteArrayRegion(env, data_, offset, readCount, data);  // copy
     }
     free(data);
-    if (readCount == 0) {
-        return -1;
+    if (readCount <= 0) {
+        switch (readCount) {
+            /* For return values READ_EOF and READ_COMPLETE, return -1 to indicate stream is
+             * complete. */
+            case RTMP_READ_EOF:
+            case RTMP_READ_COMPLETE:
+                return -1;
+
+            case RTMP_READ_IGNORE:
+            case RTMP_READ_ERROR:
+            default:
+                return 0;
+        }
     }
  	return readCount;
 }

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -4971,16 +4971,17 @@ int
 RTMP_Read(RTMP *r, char *buf, int size)
 {
   int nRead = 0, total = 0;
+  int8_t readStatus;
 
   /* can't continue */
 fail:
-  switch (r->m_read.status) {
+  readStatus = r->m_read.status;
+  switch (readStatus) {
   case RTMP_READ_ERROR:  /* corrupted stream, resume failed */
     SetSockError(EINVAL);
-    return r->m_read.status;
   case RTMP_READ_EOF:
   case RTMP_READ_COMPLETE:
-    return r->m_read.status;
+    return readStatus;
   default:
     break;
   }

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -4975,12 +4975,11 @@ RTMP_Read(RTMP *r, char *buf, int size)
   /* can't continue */
 fail:
   switch (r->m_read.status) {
+  case RTMP_READ_ERROR:  /* corrupted stream, resume failed */
+      SetSockError(EINVAL);
   case RTMP_READ_EOF:
   case RTMP_READ_COMPLETE:
-    return 0;
-  case RTMP_READ_ERROR:  /* corrupted stream, resume failed */
-    SetSockError(EINVAL);
-    return -1;
+    return r->m_read.status;
   default:
     break;
   }

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -4979,6 +4979,7 @@ fail:
   switch (readStatus) {
   case RTMP_READ_ERROR:  /* corrupted stream, resume failed */
     SetSockError(EINVAL);
+    return readStatus;
   case RTMP_READ_EOF:
   case RTMP_READ_COMPLETE:
     return readStatus;

--- a/rtmp-client/src/main/cpp/librtmp/rtmp.c
+++ b/rtmp-client/src/main/cpp/librtmp/rtmp.c
@@ -4976,7 +4976,8 @@ RTMP_Read(RTMP *r, char *buf, int size)
 fail:
   switch (r->m_read.status) {
   case RTMP_READ_ERROR:  /* corrupted stream, resume failed */
-      SetSockError(EINVAL);
+    SetSockError(EINVAL);
+    return r->m_read.status;
   case RTMP_READ_EOF:
   case RTMP_READ_COMPLETE:
     return r->m_read.status;


### PR DESCRIPTION
Propagate the error codes from RTMP read to nativeRead function and
return errors as expected. This commit also corrects exception throws
from nativeRead.