### PR TITLE
docs: fix simple typo, successfull -> successful

### DIFF
--- a/rtmp-client/src/main/cpp/rtmpmuxer.c
+++ b/rtmp-client/src/main/cpp/rtmpmuxer.c
@@ -6,7 +6,7 @@
 
 
 /**
- * if it returns bigger than 0 it is successfull
+ * if it returns bigger than 0 it is successful
  */
 JNIEXPORT jint JNICALL
 Java_net_butterflytv_rtmp_1client_RTMPMuxer_open(JNIEnv* env, jobject thiz, jstring url_,


### PR DESCRIPTION
There is a small typo in rtmp-client/src/main/cpp/rtmpmuxer.c.

Should read `successful` rather than `successfull`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md